### PR TITLE
Add comprehensive validation and acceptance tests for ACL resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,20 @@ jobs:
 
           echo "CIVICRM_API_KEY=${API_KEY}" >> "$GITHUB_OUTPUT"
 
+      - name: Log valid ACL object_table values from CiviCRM schema
+        # object_table is a free varchar in civicrm_acl — no DB-level enum.
+        # This step queries the live CiviCRM instance so the authoritative list
+        # is visible in the CI log and can be used to keep provider docs in sync.
+        run: |
+          echo "=== ACL.getFields: object_table field definition ==="
+          docker compose exec -T civi bash -c \
+            "echo '{\"where\":[[\"name\",\"=\",\"object_table\"]]}' \
+             | cv api4 ACL.getFields --in=json --out=json-pretty" || true
+          echo "=== ACL.getFields: entity_table field definition ==="
+          docker compose exec -T civi bash -c \
+            "echo '{\"where\":[[\"name\",\"=\",\"entity_table\"]]}' \
+             | cv api4 ACL.getFields --in=json --out=json-pretty" || true
+
       - name: Run acceptance tests
         env:
           TF_ACC: "1"

--- a/internal/provider/resource_acl.go
+++ b/internal/provider/resource_acl.go
@@ -25,19 +25,12 @@ var (
 )
 
 // validACLOperations lists the operations accepted by CiviCRM's ACL engine.
+// Source: civicrm_acl schema comment ("What operation does this ACL apply to?").
 var validACLOperations = []string{"Edit", "View", "Create", "Delete", "Search", "All"}
 
 // validACLEntityTables lists the entity_table values supported for ACL ownership.
+// Source: CiviCRM admin UI and existing acceptance tests.
 var validACLEntityTables = []string{"civicrm_acl_role", "civicrm_group"}
-
-// validACLObjectTables lists the object types that CiviCRM ACLs can permission.
-var validACLObjectTables = []string{
-	"civicrm_group",
-	"civicrm_saved_search",
-	"civicrm_uf_group",
-	"civicrm_custom_group",
-	"civicrm_event",
-}
 
 // ACLResource manages ACL rules in CiviCRM.
 // ACL rules define what operations a role can perform on specific data.
@@ -110,10 +103,20 @@ func (r *ACLResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 			"object_table": schema.StringAttribute{
-				Description: "The type of object being permissioned. Allowed values: civicrm_group, civicrm_saved_search, civicrm_uf_group, civicrm_custom_group, civicrm_event.",
-				Required:    true,
+				// object_table is a free varchar in CiviCRM's schema with no DB-level enum
+				// constraint.  Known values from the CiviCRM admin UI are:
+				//   civicrm_group          – static group contacts
+				//   civicrm_saved_search   – smart group contacts
+				//   civicrm_uf_group       – profiles
+				//   civicrm_custom_group   – custom data groups
+				// The authoritative list for your CiviCRM version can be retrieved via:
+				//   cv api4 ACL.getFields +s name +w name=object_table
+				Description: "The CiviCRM table whose records this ACL permissions. " +
+					"Common values: civicrm_group, civicrm_saved_search, civicrm_uf_group, civicrm_custom_group. " +
+					"Run 'cv api4 ACL.getFields' to see the authoritative list for your CiviCRM version.",
+				Required: true,
 				Validators: []validator.String{
-					stringOneOf(validACLObjectTables...),
+					stringLengthAtLeast(1),
 				},
 			},
 			"object_id": schema.Int64Attribute{

--- a/internal/provider/resource_acl.go
+++ b/internal/provider/resource_acl.go
@@ -32,6 +32,19 @@ var validACLOperations = []string{"Edit", "View", "Create", "Delete", "Search", 
 // Source: CiviCRM admin UI and existing acceptance tests.
 var validACLEntityTables = []string{"civicrm_acl_role", "civicrm_group"}
 
+// validACLObjectTables lists the object types that CiviCRM's ACL engine actually evaluates.
+// Source: CRM/ACL/BAO/ACL.php::getObjectTableOptions() in CiviCRM 6.6.
+// Any other value is silently stored but never enforced — use terraform validate to catch this early.
+// Note: civicrm_group covers both static groups AND smart groups (smart groups are stored as
+// civicrm_group rows with a saved_search_id column; there is no separate civicrm_saved_search object type).
+// Note: civicrm_event requires the CiviEvent component to be enabled.
+var validACLObjectTables = []string{
+	"civicrm_group",
+	"civicrm_uf_group",
+	"civicrm_custom_group",
+	"civicrm_event",
+}
+
 // ACLResource manages ACL rules in CiviCRM.
 // ACL rules define what operations a role can perform on specific data.
 type ACLResource struct {
@@ -103,20 +116,14 @@ func (r *ACLResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 			"object_table": schema.StringAttribute{
-				// object_table is a free varchar in CiviCRM's schema with no DB-level enum
-				// constraint.  Known values from the CiviCRM admin UI are:
-				//   civicrm_group          – static group contacts
-				//   civicrm_saved_search   – smart group contacts
-				//   civicrm_uf_group       – profiles
-				//   civicrm_custom_group   – custom data groups
-				// The authoritative list for your CiviCRM version can be retrieved via:
-				//   cv api4 ACL.getFields +s name +w name=object_table
-				Description: "The CiviCRM table whose records this ACL permissions. " +
-					"Common values: civicrm_group, civicrm_saved_search, civicrm_uf_group, civicrm_custom_group. " +
-					"Run 'cv api4 ACL.getFields' to see the authoritative list for your CiviCRM version.",
+				Description: "The type of object this ACL permissions. " +
+					"Allowed values (from CRM/ACL/BAO/ACL.php::getObjectTableOptions()): " +
+					"civicrm_group (static and smart groups), civicrm_uf_group (profiles), " +
+					"civicrm_custom_group (custom data), civicrm_event (requires CiviEvent). " +
+					"Other values are silently stored but never evaluated by CiviCRM's ACL engine.",
 				Required: true,
 				Validators: []validator.String{
-					stringLengthAtLeast(1),
+					stringOneOf(validACLObjectTables...),
 				},
 			},
 			"object_id": schema.Int64Attribute{

--- a/internal/provider/resource_acl.go
+++ b/internal/provider/resource_acl.go
@@ -12,15 +12,32 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
-	_ resource.Resource                = &ACLResource{}
-	_ resource.ResourceWithConfigure   = &ACLResource{}
-	_ resource.ResourceWithImportState = &ACLResource{}
+	_ resource.Resource                  = &ACLResource{}
+	_ resource.ResourceWithConfigure     = &ACLResource{}
+	_ resource.ResourceWithImportState   = &ACLResource{}
+	_ resource.ResourceWithValidateConfig = &ACLResource{}
 )
+
+// validACLOperations lists the operations accepted by CiviCRM's ACL engine.
+var validACLOperations = []string{"Edit", "View", "Create", "Delete", "Search", "All"}
+
+// validACLEntityTables lists the entity_table values supported for ACL ownership.
+var validACLEntityTables = []string{"civicrm_acl_role", "civicrm_group"}
+
+// validACLObjectTables lists the object types that CiviCRM ACLs can permission.
+var validACLObjectTables = []string{
+	"civicrm_group",
+	"civicrm_saved_search",
+	"civicrm_uf_group",
+	"civicrm_custom_group",
+	"civicrm_event",
+}
 
 // ACLResource manages ACL rules in CiviCRM.
 // ACL rules define what operations a role can perform on specific data.
@@ -65,24 +82,39 @@ func (r *ACLResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"name": schema.StringAttribute{
 				Description: "The name of the ACL rule.",
 				Required:    true,
+				Validators: []validator.String{
+					stringLengthAtLeast(1),
+				},
 			},
 			"entity_table": schema.StringAttribute{
 				Description: "The entity table that owns this ACL (typically 'civicrm_acl_role'). Default: 'civicrm_acl_role'.",
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("civicrm_acl_role"),
+				Validators: []validator.String{
+					stringOneOf(validACLEntityTables...),
+				},
 			},
 			"entity_id": schema.Int64Attribute{
 				Description: "The value field of the ACL role this rule belongs to. Use tonumber(civicrm_acl_role.example.value) to reference an ACL role.",
 				Required:    true,
+				Validators: []validator.Int64{
+					int64AtLeast(1),
+				},
 			},
 			"operation": schema.StringAttribute{
 				Description: "The operation this ACL grants. Options: 'Edit', 'View', 'Create', 'Delete', 'Search', 'All'.",
 				Required:    true,
+				Validators: []validator.String{
+					stringOneOf(validACLOperations...),
+				},
 			},
 			"object_table": schema.StringAttribute{
-				Description: "The type of object being permissioned (e.g., 'civicrm_group', 'civicrm_saved_search', 'civicrm_uf_group').",
+				Description: "The type of object being permissioned. Allowed values: civicrm_group, civicrm_saved_search, civicrm_uf_group, civicrm_custom_group, civicrm_event.",
 				Required:    true,
+				Validators: []validator.String{
+					stringOneOf(validACLObjectTables...),
+				},
 			},
 			"object_id": schema.Int64Attribute{
 				Description: "The ID of the specific object being permissioned. Leave empty (null) for all objects of the given type.",
@@ -496,4 +528,31 @@ func (r *ACLResource) ImportState(ctx context.Context, req resource.ImportStateR
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+}
+
+// ValidateConfig enforces cross-field constraints that cannot be expressed in individual field validators.
+func (r *ACLResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config ACLResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// acl_table and acl_id must be set together — one without the other is invalid.
+	aclTableSet := !config.AclTable.IsNull() && !config.AclTable.IsUnknown()
+	aclIDSet := !config.AclID.IsNull() && !config.AclID.IsUnknown()
+	if aclTableSet && !aclIDSet {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("acl_id"),
+			"Missing acl_id",
+			"acl_id must be set when acl_table is specified.",
+		)
+	}
+	if aclIDSet && !aclTableSet {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("acl_table"),
+			"Missing acl_table",
+			"acl_table must be set when acl_id is specified.",
+		)
+	}
 }

--- a/internal/provider/resource_acl.go
+++ b/internal/provider/resource_acl.go
@@ -32,12 +32,19 @@ var validACLOperations = []string{"Edit", "View", "Create", "Delete", "Search", 
 // Source: CiviCRM admin UI and existing acceptance tests.
 var validACLEntityTables = []string{"civicrm_acl_role", "civicrm_group"}
 
-// validACLObjectTables lists the object types that CiviCRM's ACL engine actually evaluates.
-// Source: CRM/ACL/BAO/ACL.php::getObjectTableOptions() in CiviCRM 6.6.
-// Any other value is silently stored but never enforced — use terraform validate to catch this early.
-// Note: civicrm_group covers both static groups AND smart groups (smart groups are stored as
-// civicrm_group rows with a saved_search_id column; there is no separate civicrm_saved_search object type).
-// Note: civicrm_event requires the CiviEvent component to be enabled.
+// validACLObjectTables are the only object_table values that CiviCRM's ACL engine actively enforces.
+// Verified against CiviCRM 6.6 source:
+//
+//	CRM/ACL/BAO/ACL.php::getObjectTableOptions()   – canonical enum definition
+//	CRM/Core/Permission.php::customGroup()         – enforces civicrm_custom_group
+//	CRM/Core/Permission.php::ufGroup()             – enforces civicrm_uf_group
+//	CRM/Core/Permission.php::event()               – enforces civicrm_event
+//	CRM/ACL/BAO/ACL.php::whereClause()             – enforces civicrm_group (contact access)
+//
+// Any other value (e.g. civicrm_saved_search) is silently accepted by the API but never evaluated
+// by the ACL engine. Smart groups are civicrm_group rows with a saved_search_id column — there is
+// no separate civicrm_saved_search object type.
+// civicrm_event requires the CiviEvent component (cv en civi_event).
 var validACLObjectTables = []string{
 	"civicrm_group",
 	"civicrm_uf_group",

--- a/internal/provider/resource_acl_entity_role.go
+++ b/internal/provider/resource_acl_entity_role.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -59,16 +60,25 @@ func (r *ACLEntityRoleResource) Schema(ctx context.Context, req resource.SchemaR
 			"acl_role_id": schema.Int64Attribute{
 				Description: "The value field of the ACL role to assign. Use tonumber(civicrm_acl_role.example.value) to reference an ACL role.",
 				Required:    true,
+				Validators: []validator.Int64{
+					int64AtLeast(1),
+				},
 			},
 			"entity_table": schema.StringAttribute{
-				Description: "The table containing the entity to assign the role to. Default: 'civicrm_group'.",
+				Description: "The table containing the entity to assign the role to. Currently only 'civicrm_group' is supported. Default: 'civicrm_group'.",
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("civicrm_group"),
+				Validators: []validator.String{
+					stringOneOf("civicrm_group"),
+				},
 			},
 			"entity_id": schema.Int64Attribute{
 				Description: "The ID of the group (or other entity) to assign the ACL role to.",
 				Required:    true,
+				Validators: []validator.Int64{
+					int64AtLeast(1),
+				},
 			},
 			"is_active": schema.BoolAttribute{
 				Description: "Whether this role assignment is active. Default: true.",

--- a/internal/provider/resource_acl_permissions_test.go
+++ b/internal/provider/resource_acl_permissions_test.go
@@ -1,0 +1,343 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestAccACLFullChain tests the complete CiviCRM permission model:
+//   civicrm_acl_role  → defines a role
+//   civicrm_acl_entity_role → assigns the role to a group (group members carry the role)
+//   civicrm_acl        → grants an operation on an object to that role
+//
+// All three resources are created and linked together; the test verifies the
+// relationships are stored correctly in CiviCRM via the API.
+func TestAccACLFullChain(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			checkDestroyByID(t, "ACL", "civicrm_acl.chain_rule"),
+			checkDestroyByID(t, "ACLEntityRole", "civicrm_acl_entity_role.chain_assign"),
+			checkDestroyByID(t, "OptionValue", "civicrm_acl_role.chain_role"),
+			checkDestroyByID(t, "Group", "civicrm_group.chain_group"),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + testAccACLFullChainConfig("View"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Role exists and has a value
+					resource.TestCheckResourceAttrSet("civicrm_acl_role.chain_role", "id"),
+					resource.TestCheckResourceAttrSet("civicrm_acl_role.chain_role", "value"),
+					resource.TestCheckResourceAttr("civicrm_acl_role.chain_role", "name", "tf_acc_chain_role"),
+					resource.TestCheckResourceAttr("civicrm_acl_role.chain_role", "is_active", "true"),
+
+					// Group exists
+					resource.TestCheckResourceAttrSet("civicrm_acl_entity_role.chain_assign", "id"),
+					resource.TestCheckResourceAttr("civicrm_acl_entity_role.chain_assign", "entity_table", "civicrm_group"),
+					resource.TestCheckResourceAttr("civicrm_acl_entity_role.chain_assign", "is_active", "true"),
+
+					// ACL rule is linked to the role and targets the right object
+					resource.TestCheckResourceAttrSet("civicrm_acl.chain_rule", "id"),
+					resource.TestCheckResourceAttr("civicrm_acl.chain_rule", "operation", "View"),
+					resource.TestCheckResourceAttr("civicrm_acl.chain_rule", "object_table", "civicrm_group"),
+					resource.TestCheckResourceAttr("civicrm_acl.chain_rule", "is_active", "true"),
+					resource.TestCheckResourceAttr("civicrm_acl.chain_rule", "deny", "false"),
+					resource.TestCheckResourceAttrSet("civicrm_acl.chain_rule", "priority"),
+
+					// DB verification: role fields stored correctly
+					checkEntityAttr(t, "OptionValue", "civicrm_acl_role.chain_role", "id", "name", "tf_acc_chain_role"),
+					checkEntityAttr(t, "OptionValue", "civicrm_acl_role.chain_role", "id", "label", "TF Acceptance Chain Role"),
+
+					// DB verification: entity role links the right group
+					checkEntityAttr(t, "ACLEntityRole", "civicrm_acl_entity_role.chain_assign", "id", "entity_table", "civicrm_group"),
+					checkEntityAttr(t, "ACLEntityRole", "civicrm_acl_entity_role.chain_assign", "id", "is_active", "true"),
+
+					// DB verification: ACL rule operation and object
+					checkEntityAttr(t, "ACL", "civicrm_acl.chain_rule", "id", "operation", "View"),
+					checkEntityAttr(t, "ACL", "civicrm_acl.chain_rule", "id", "object_table", "civicrm_group"),
+					checkEntityAttr(t, "ACL", "civicrm_acl.chain_rule", "id", "is_active", "true"),
+
+					// entity_id in ACL must equal the role's value field
+					testCheckACLEntityIDMatchesRoleValue("civicrm_acl.chain_rule", "civicrm_acl_role.chain_role"),
+					// acl_role_id in entity_role must equal the role's value field
+					testCheckEntityRoleMatchesRoleValue("civicrm_acl_entity_role.chain_assign", "civicrm_acl_role.chain_role"),
+					// entity_id in entity_role must equal the group's id
+					testCheckEntityRoleEntityIDMatchesGroup("civicrm_acl_entity_role.chain_assign", "civicrm_group.chain_group"),
+				),
+			},
+			// Update operation — verifies that changing the permission works correctly
+			{
+				Config: providerConfig() + testAccACLFullChainConfig("Edit"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("civicrm_acl.chain_rule", "operation", "Edit"),
+					checkEntityAttr(t, "ACL", "civicrm_acl.chain_rule", "id", "operation", "Edit"),
+					resource.TestCheckResourceAttrSet("civicrm_acl.chain_rule", "priority"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccACLDenyRule verifies that a deny ACL rule (deny=true) is created and stored correctly.
+func TestAccACLDenyRule(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             checkDestroyByID(t, "ACL", "civicrm_acl.deny_rule"),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "deny_rule" {
+  name         = "tf_acc_deny_rule"
+  entity_table = "civicrm_acl_role"
+  entity_id    = 1
+  operation    = "Edit"
+  object_table = "civicrm_group"
+  deny         = true
+  is_active    = true
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("civicrm_acl.deny_rule", "deny", "true"),
+					resource.TestCheckResourceAttr("civicrm_acl.deny_rule", "operation", "Edit"),
+					checkEntityAttr(t, "ACL", "civicrm_acl.deny_rule", "id", "deny", "true"),
+					checkEntityAttr(t, "ACL", "civicrm_acl.deny_rule", "id", "operation", "Edit"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccACLDeactivation verifies that a permission rule can be deactivated via is_active=false.
+func TestAccACLDeactivation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             checkDestroyByID(t, "ACL", "civicrm_acl.deactivate_test"),
+		Steps: []resource.TestStep{
+			// Create active
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "deactivate_test" {
+  name         = "tf_acc_deactivate"
+  entity_table = "civicrm_acl_role"
+  entity_id    = 1
+  operation    = "View"
+  object_table = "civicrm_group"
+  is_active    = true
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("civicrm_acl.deactivate_test", "is_active", "true"),
+					checkEntityAttr(t, "ACL", "civicrm_acl.deactivate_test", "id", "is_active", "true"),
+				),
+			},
+			// Deactivate
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "deactivate_test" {
+  name         = "tf_acc_deactivate"
+  entity_table = "civicrm_acl_role"
+  entity_id    = 1
+  operation    = "View"
+  object_table = "civicrm_group"
+  is_active    = false
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("civicrm_acl.deactivate_test", "is_active", "false"),
+					checkEntityAttr(t, "ACL", "civicrm_acl.deactivate_test", "id", "is_active", "false"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccACLObjectIDLink tests that object_id correctly references an existing group, and
+// that the ACL is scoped to that specific group (not all groups).
+func TestAccACLObjectIDLink(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			checkDestroyByID(t, "ACL", "civicrm_acl.scoped_rule"),
+			checkDestroyByID(t, "Group", "civicrm_group.acl_target_group"),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_group" "acl_target_group" {
+  name  = "tf_acc_acl_target_group"
+  title = "TF Acceptance ACL Target Group"
+}
+
+resource "civicrm_acl" "scoped_rule" {
+  name         = "tf_acc_scoped_acl"
+  entity_table = "civicrm_acl_role"
+  entity_id    = 1
+  operation    = "View"
+  object_table = "civicrm_group"
+  object_id    = civicrm_group.acl_target_group.id
+  is_active    = true
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("civicrm_acl.scoped_rule", "object_id"),
+					// object_id in ACL must equal the referenced group's id
+					testCheckACLObjectIDMatchesGroup("civicrm_acl.scoped_rule", "civicrm_group.acl_target_group"),
+					checkEntityAttr(t, "ACL", "civicrm_acl.scoped_rule", "id", "object_table", "civicrm_group"),
+					checkEntityAttr(t, "ACL", "civicrm_acl.scoped_rule", "id", "operation", "View"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccACLAllOperations ensures all valid operation values are accepted by CiviCRM.
+func TestAccACLAllOperations(t *testing.T) {
+	operations := []string{"Edit", "View", "Create", "Delete", "Search", "All"}
+
+	for _, op := range operations {
+		op := op // capture loop variable
+		t.Run(op, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				CheckDestroy:             checkDestroyByID(t, "ACL", "civicrm_acl.op_test"),
+				Steps: []resource.TestStep{
+					{
+						Config: providerConfig() + fmt.Sprintf(`
+resource "civicrm_acl" "op_test" {
+  name         = "tf_acc_op_%s"
+  entity_table = "civicrm_acl_role"
+  entity_id    = 1
+  operation    = %q
+  object_table = "civicrm_group"
+  is_active    = true
+}`, op, op),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr("civicrm_acl.op_test", "operation", op),
+							checkEntityAttr(t, "ACL", "civicrm_acl.op_test", "id", "operation", op),
+						),
+					},
+				},
+			})
+		})
+	}
+}
+
+// --- helpers ---
+
+func testAccACLFullChainConfig(operation string) string {
+	return fmt.Sprintf(`
+resource "civicrm_group" "chain_group" {
+  name  = "tf_acc_chain_group"
+  title = "TF Acceptance Chain Group"
+}
+
+resource "civicrm_acl_role" "chain_role" {
+  name      = "tf_acc_chain_role"
+  label     = "TF Acceptance Chain Role"
+  is_active = true
+}
+
+resource "civicrm_acl_entity_role" "chain_assign" {
+  acl_role_id  = civicrm_acl_role.chain_role.value
+  entity_table = "civicrm_group"
+  entity_id    = civicrm_group.chain_group.id
+  is_active    = true
+}
+
+resource "civicrm_acl" "chain_rule" {
+  name         = "tf_acc_chain_acl"
+  entity_table = "civicrm_acl_role"
+  entity_id    = civicrm_acl_role.chain_role.value
+  operation    = %q
+  object_table = "civicrm_group"
+  object_id    = civicrm_group.chain_group.id
+  is_active    = true
+
+  depends_on = [civicrm_acl_entity_role.chain_assign]
+}
+`, operation)
+}
+
+// testCheckACLEntityIDMatchesRoleValue verifies that the ACL's entity_id equals the role's value.
+func testCheckACLEntityIDMatchesRoleValue(aclAddr, roleAddr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		aclRS, ok := s.RootModule().Resources[aclAddr]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", aclAddr)
+		}
+		roleRS, ok := s.RootModule().Resources[roleAddr]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", roleAddr)
+		}
+		aclEntityID := aclRS.Primary.Attributes["entity_id"]
+		roleValue := roleRS.Primary.Attributes["value"]
+		if aclEntityID != roleValue {
+			return fmt.Errorf("ACL entity_id (%s) does not match acl_role.value (%s) — the ACL rule is not linked to the role", aclEntityID, roleValue)
+		}
+		return nil
+	}
+}
+
+// testCheckEntityRoleMatchesRoleValue verifies that the entity_role's acl_role_id equals the role's value.
+func testCheckEntityRoleMatchesRoleValue(entityRoleAddr, roleAddr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		erRS, ok := s.RootModule().Resources[entityRoleAddr]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", entityRoleAddr)
+		}
+		roleRS, ok := s.RootModule().Resources[roleAddr]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", roleAddr)
+		}
+		erRoleID := erRS.Primary.Attributes["acl_role_id"]
+		roleValue := roleRS.Primary.Attributes["value"]
+		if erRoleID != roleValue {
+			return fmt.Errorf("acl_entity_role.acl_role_id (%s) does not match acl_role.value (%s)", erRoleID, roleValue)
+		}
+		return nil
+	}
+}
+
+// testCheckEntityRoleEntityIDMatchesGroup verifies that the entity_role's entity_id equals the group's id.
+func testCheckEntityRoleEntityIDMatchesGroup(entityRoleAddr, groupAddr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		erRS, ok := s.RootModule().Resources[entityRoleAddr]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", entityRoleAddr)
+		}
+		grpRS, ok := s.RootModule().Resources[groupAddr]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", groupAddr)
+		}
+		erEntityID := erRS.Primary.Attributes["entity_id"]
+		groupID := grpRS.Primary.ID
+		if erEntityID != groupID {
+			return fmt.Errorf("acl_entity_role.entity_id (%s) does not match group.id (%s)", erEntityID, groupID)
+		}
+		return nil
+	}
+}
+
+// testCheckACLObjectIDMatchesGroup verifies that the ACL's object_id equals the group's id.
+func testCheckACLObjectIDMatchesGroup(aclAddr, groupAddr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		aclRS, ok := s.RootModule().Resources[aclAddr]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", aclAddr)
+		}
+		grpRS, ok := s.RootModule().Resources[groupAddr]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", groupAddr)
+		}
+		objectID := aclRS.Primary.Attributes["object_id"]
+		groupID := grpRS.Primary.ID
+		if objectID != groupID {
+			return fmt.Errorf("acl.object_id (%s) does not match group.id (%s) — cross-resource link is broken", objectID, groupID)
+		}
+		return nil
+	}
+}

--- a/internal/provider/resource_acl_permissions_test.go
+++ b/internal/provider/resource_acl_permissions_test.go
@@ -226,6 +226,54 @@ resource "civicrm_acl" "op_test" {
 	}
 }
 
+// TestAccACLAllObjectTables verifies that the object_table values known from the
+// CiviCRM admin UI are actually accepted by the live CiviCRM instance.
+// This is the acceptance-test complement to the informational CI log step
+// "Log valid ACL object_table values from CiviCRM schema".
+//
+// object_table is a free varchar in civicrm_acl — CiviCRM does not enforce an enum
+// at the DB or API level.  This test creates one ACL per known value and confirms
+// CiviCRM stores it without error.  If a future CiviCRM version removes a value,
+// this test will catch it so the provider documentation can be updated.
+func TestAccACLAllObjectTables(t *testing.T) {
+	// Values shown in the CiviCRM ACL admin UI under "Type of Data".
+	// Do NOT add values here without confirming against a running CiviCRM instance.
+	knownObjectTables := []string{
+		"civicrm_group",         // static group contacts
+		"civicrm_saved_search",  // smart group contacts
+		"civicrm_uf_group",      // profiles
+		"civicrm_custom_group",  // custom data groups
+	}
+
+	for _, tbl := range knownObjectTables {
+		tbl := tbl // capture loop variable
+		t.Run(tbl, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				CheckDestroy:             checkDestroyByID(t, "ACL", "civicrm_acl.objtbl_test"),
+				Steps: []resource.TestStep{
+					{
+						Config: providerConfig() + fmt.Sprintf(`
+resource "civicrm_acl" "objtbl_test" {
+  name         = "tf_acc_objtbl_%s"
+  entity_table = "civicrm_acl_role"
+  entity_id    = 1
+  operation    = "View"
+  object_table = %q
+  is_active    = true
+}`, tbl, tbl),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr("civicrm_acl.objtbl_test", "object_table", tbl),
+							checkEntityAttr(t, "ACL", "civicrm_acl.objtbl_test", "id", "object_table", tbl),
+						),
+					},
+				},
+			})
+		})
+	}
+}
+
 // --- helpers ---
 
 func testAccACLFullChainConfig(operation string) string {

--- a/internal/provider/resource_acl_permissions_test.go
+++ b/internal/provider/resource_acl_permissions_test.go
@@ -236,13 +236,14 @@ resource "civicrm_acl" "op_test" {
 // CiviCRM stores it without error.  If a future CiviCRM version removes a value,
 // this test will catch it so the provider documentation can be updated.
 func TestAccACLAllObjectTables(t *testing.T) {
-	// Values shown in the CiviCRM ACL admin UI under "Type of Data".
-	// Do NOT add values here without confirming against a running CiviCRM instance.
+	// Source: CRM/ACL/BAO/ACL.php::getObjectTableOptions() in CiviCRM 6.6.
+	// civicrm_group covers both static and smart groups (smart groups are civicrm_group
+	// rows with a saved_search_id; there is no separate civicrm_saved_search object type).
 	knownObjectTables := []string{
-		"civicrm_group",         // static group contacts
-		"civicrm_saved_search",  // smart group contacts
-		"civicrm_uf_group",      // profiles
-		"civicrm_custom_group",  // custom data groups
+		"civicrm_group",
+		"civicrm_uf_group",
+		"civicrm_custom_group",
+		"civicrm_event",
 	}
 
 	for _, tbl := range knownObjectTables {

--- a/internal/provider/resource_acl_role.go
+++ b/internal/provider/resource_acl_role.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -59,10 +60,16 @@ func (r *ACLRoleResource) Schema(ctx context.Context, req resource.SchemaRequest
 			"name": schema.StringAttribute{
 				Description: "The machine name of the ACL role.",
 				Required:    true,
+				Validators: []validator.String{
+					stringLengthAtLeast(1),
+				},
 			},
 			"label": schema.StringAttribute{
 				Description: "The display label of the ACL role.",
 				Required:    true,
+				Validators: []validator.String{
+					stringLengthAtLeast(1),
+				},
 			},
 			"description": schema.StringAttribute{
 				Description: "A description of the ACL role.",

--- a/internal/provider/resource_acl_test.go
+++ b/internal/provider/resource_acl_test.go
@@ -32,7 +32,7 @@ resource "civicrm_acl" "test" {
   entity_table = "civicrm_group"
   entity_id    = civicrm_group.acl_test.id
   operation    = "View"
-  object_table = "civicrm_saved_search"
+  object_table = "civicrm_group"
   is_active    = true
 }`,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -73,7 +73,7 @@ resource "civicrm_acl" "test" {
   entity_table = "civicrm_group"
   entity_id    = civicrm_group.acl_test.id
   operation    = "Edit"
-  object_table = "civicrm_saved_search"
+  object_table = "civicrm_group"
   is_active    = true
 }`,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/resource_acl_validate_test.go
+++ b/internal/provider/resource_acl_validate_test.go
@@ -28,13 +28,12 @@ resource "civicrm_acl" "test" {
 	})
 }
 
-// Note: object_table is a free varchar in CiviCRM with no DB-level enum.
-// The valid values depend on the CiviCRM version and installed extensions.
-// Validation is intentionally not an enum — CiviCRM itself is the authority.
-// The acceptance test TestAccACLAllObjectTables verifies the known values against
-// the live CiviCRM instance.
-
-func TestACLResource_Validate_EmptyObjectTable(t *testing.T) {
+// TestACLResource_Validate_InvalidObjectTable tests that object_table values not in
+// CRM/ACL/BAO/ACL.php::getObjectTableOptions() are rejected at plan time.
+// This prevents silent failures where CiviCRM stores the rule but never evaluates it.
+// civicrm_saved_search is the canonical example: CiviCRM 6.6 stores it without error
+// but the ACL engine never checks it (smart groups are addressed via civicrm_group).
+func TestACLResource_Validate_InvalidObjectTable(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -44,9 +43,27 @@ resource "civicrm_acl" "test" {
   name         = "tf_unit_acl"
   entity_id    = 1
   operation    = "View"
-  object_table = ""
+  object_table = "civicrm_saved_search"
 }`,
-				ExpectError: regexp.MustCompile(`(?i)too short|at least 1`),
+				ExpectError: regexp.MustCompile(`(?i)civicrm_saved_search.*not a valid|not a valid.*civicrm_saved_search`),
+			},
+		},
+	})
+}
+
+func TestACLResource_Validate_UnknownObjectTable(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "test" {
+  name         = "tf_unit_acl"
+  entity_id    = 1
+  operation    = "View"
+  object_table = "civicrm_contact"
+}`,
+				ExpectError: regexp.MustCompile(`(?i)civicrm_contact.*not a valid|not a valid.*civicrm_contact`),
 			},
 		},
 	})

--- a/internal/provider/resource_acl_validate_test.go
+++ b/internal/provider/resource_acl_validate_test.go
@@ -1,0 +1,228 @@
+package provider_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// Unit tests for schema-level validation. These run without TF_ACC and without a real CiviCRM
+// instance because the errors are raised during plan validation, before any API call is made.
+
+func TestACLResource_Validate_InvalidOperation(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "test" {
+  name         = "tf_unit_acl"
+  entity_id    = 1
+  operation    = "BadOp"
+  object_table = "civicrm_group"
+}`,
+				ExpectError: regexp.MustCompile(`(?i)BadOp.*not a valid|not a valid.*BadOp`),
+			},
+		},
+	})
+}
+
+func TestACLResource_Validate_InvalidObjectTable(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "test" {
+  name         = "tf_unit_acl"
+  entity_id    = 1
+  operation    = "View"
+  object_table = "civicrm_nonexistent"
+}`,
+				ExpectError: regexp.MustCompile(`(?i)civicrm_nonexistent.*not a valid|not a valid.*civicrm_nonexistent`),
+			},
+		},
+	})
+}
+
+func TestACLResource_Validate_InvalidEntityTable(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "test" {
+  name         = "tf_unit_acl"
+  entity_table = "civicrm_contact"
+  entity_id    = 1
+  operation    = "View"
+  object_table = "civicrm_group"
+}`,
+				ExpectError: regexp.MustCompile(`(?i)civicrm_contact.*not a valid|not a valid.*civicrm_contact`),
+			},
+		},
+	})
+}
+
+func TestACLResource_Validate_EmptyName(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "test" {
+  name         = ""
+  entity_id    = 1
+  operation    = "View"
+  object_table = "civicrm_group"
+}`,
+				ExpectError: regexp.MustCompile(`(?i)too short|at least 1`),
+			},
+		},
+	})
+}
+
+func TestACLResource_Validate_EntityIDZero(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "test" {
+  name         = "tf_unit_acl"
+  entity_id    = 0
+  operation    = "View"
+  object_table = "civicrm_group"
+}`,
+				ExpectError: regexp.MustCompile(`(?i)at least 1|too small`),
+			},
+		},
+	})
+}
+
+// TestACLResource_Validate_AclTableWithoutAclID checks that providing acl_table without acl_id
+// is caught by the cross-field ValidateConfig.
+func TestACLResource_Validate_AclTableWithoutAclID(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "test" {
+  name         = "tf_unit_acl"
+  entity_id    = 1
+  operation    = "View"
+  object_table = "civicrm_group"
+  acl_table    = "civicrm_acl"
+}`,
+				ExpectError: regexp.MustCompile(`(?i)acl_id.*must be set|Missing acl_id`),
+			},
+		},
+	})
+}
+
+// TestACLResource_Validate_AclIDWithoutAclTable checks the inverse cross-field constraint.
+func TestACLResource_Validate_AclIDWithoutAclTable(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl" "test" {
+  name         = "tf_unit_acl"
+  entity_id    = 1
+  operation    = "View"
+  object_table = "civicrm_group"
+  acl_id       = 42
+}`,
+				ExpectError: regexp.MustCompile(`(?i)acl_table.*must be set|Missing acl_table`),
+			},
+		},
+	})
+}
+
+// --- ACL Role unit validation tests ---
+
+func TestACLRoleResource_Validate_EmptyName(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl_role" "test" {
+  name  = ""
+  label = "My Role"
+}`,
+				ExpectError: regexp.MustCompile(`(?i)too short|at least 1`),
+			},
+		},
+	})
+}
+
+func TestACLRoleResource_Validate_EmptyLabel(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl_role" "test" {
+  name  = "my_role"
+  label = ""
+}`,
+				ExpectError: regexp.MustCompile(`(?i)too short|at least 1`),
+			},
+		},
+	})
+}
+
+// --- ACL Entity Role unit validation tests ---
+
+func TestACLEntityRoleResource_Validate_InvalidEntityTable(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl_entity_role" "test" {
+  acl_role_id  = 5
+  entity_table = "civicrm_contact"
+  entity_id    = 1
+}`,
+				ExpectError: regexp.MustCompile(`(?i)civicrm_contact.*not a valid|not a valid.*civicrm_contact`),
+			},
+		},
+	})
+}
+
+func TestACLEntityRoleResource_Validate_AclRoleIDZero(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl_entity_role" "test" {
+  acl_role_id = 0
+  entity_id   = 1
+}`,
+				ExpectError: regexp.MustCompile(`(?i)at least 1|too small`),
+			},
+		},
+	})
+}
+
+func TestACLEntityRoleResource_Validate_EntityIDZero(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig() + `
+resource "civicrm_acl_entity_role" "test" {
+  acl_role_id = 5
+  entity_id   = 0
+}`,
+				ExpectError: regexp.MustCompile(`(?i)at least 1|too small`),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_acl_validate_test.go
+++ b/internal/provider/resource_acl_validate_test.go
@@ -28,7 +28,13 @@ resource "civicrm_acl" "test" {
 	})
 }
 
-func TestACLResource_Validate_InvalidObjectTable(t *testing.T) {
+// Note: object_table is a free varchar in CiviCRM with no DB-level enum.
+// The valid values depend on the CiviCRM version and installed extensions.
+// Validation is intentionally not an enum — CiviCRM itself is the authority.
+// The acceptance test TestAccACLAllObjectTables verifies the known values against
+// the live CiviCRM instance.
+
+func TestACLResource_Validate_EmptyObjectTable(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -38,9 +44,9 @@ resource "civicrm_acl" "test" {
   name         = "tf_unit_acl"
   entity_id    = 1
   operation    = "View"
-  object_table = "civicrm_nonexistent"
+  object_table = ""
 }`,
-				ExpectError: regexp.MustCompile(`(?i)civicrm_nonexistent.*not a valid|not a valid.*civicrm_nonexistent`),
+				ExpectError: regexp.MustCompile(`(?i)too short|at least 1`),
 			},
 		},
 	})

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// stringOneOf returns a String validator that accepts only the given values.
+func stringOneOf(values ...string) validator.String {
+	return &oneOfStringValidator{values: values}
+}
+
+type oneOfStringValidator struct {
+	values []string
+}
+
+func (v *oneOfStringValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("Must be one of: %s", strings.Join(v.values, ", "))
+}
+
+func (v *oneOfStringValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v *oneOfStringValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	val := req.ConfigValue.ValueString()
+	for _, allowed := range v.values {
+		if val == allowed {
+			return
+		}
+	}
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid value",
+		fmt.Sprintf("%q is not a valid value. Allowed values: %s", val, strings.Join(v.values, ", ")),
+	)
+}
+
+// stringLengthAtLeast returns a String validator that rejects empty or too-short strings.
+func stringLengthAtLeast(n int) validator.String {
+	return &stringMinLenValidator{min: n}
+}
+
+type stringMinLenValidator struct {
+	min int
+}
+
+func (v *stringMinLenValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("Must be at least %d character(s) long", v.min)
+}
+
+func (v *stringMinLenValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v *stringMinLenValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if len(req.ConfigValue.ValueString()) < v.min {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"String too short",
+			fmt.Sprintf("Value must be at least %d character(s) long, got %q", v.min, req.ConfigValue.ValueString()),
+		)
+	}
+}
+
+// int64AtLeast returns an Int64 validator that rejects values below min.
+func int64AtLeast(min int64) validator.Int64 {
+	return &int64MinValidator{min: min}
+}
+
+type int64MinValidator struct {
+	min int64
+}
+
+func (v *int64MinValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("Must be at least %d", v.min)
+}
+
+func (v *int64MinValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v *int64MinValidator) ValidateInt64(_ context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if req.ConfigValue.ValueInt64() < v.min {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Value too small",
+			fmt.Sprintf("Value must be at least %d, got %d", v.min, req.ConfigValue.ValueInt64()),
+		)
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive schema validation and acceptance tests for CiviCRM ACL (Access Control List) resources, ensuring data integrity and correct cross-resource linking in the Terraform provider.

## Key Changes

### New Validation Framework
- **validators.go**: Introduced reusable validator functions:
  - `stringOneOf()`: Validates string values against an allowed list
  - `stringLengthAtLeast()`: Enforces minimum string length
  - `int64AtLeast()`: Enforces minimum integer values

### ACL Resource Validation
- **resource_acl.go**: Added comprehensive field validators and cross-field validation:
  - `operation` field: Restricted to valid CiviCRM operations (Edit, View, Create, Delete, Search, All)
  - `object_table` field: Restricted to tables actively enforced by CiviCRM's ACL engine (civicrm_group, civicrm_uf_group, civicrm_custom_group, civicrm_event)
  - `entity_table` field: Restricted to valid entity types (civicrm_acl_role, civicrm_group)
  - `entity_id` and `name` fields: Added minimum value/length constraints
  - Cross-field validation: Ensures `acl_table` and `acl_id` are both provided or both omitted

### ACL Role & Entity Role Validation
- **resource_acl_role.go**: Added validators for `name` and `label` fields (minimum length 1)
- **resource_acl_entity_role.go**: Added validators for `entity_table`, `acl_role_id`, and `entity_id` fields

### Comprehensive Test Suite
- **resource_acl_permissions_test.go**: Acceptance tests covering:
  - Full ACL chain: role → entity_role → ACL rule with cross-resource linking verification
  - Deny rules: Validates `deny=true` flag functionality
  - Deactivation: Tests toggling `is_active` state
  - Object ID linking: Verifies ACL scoping to specific objects
  - All valid operations: Tests each operation type (Edit, View, Create, Delete, Search, All)
  - All valid object tables: Tests each supported object table type

- **resource_acl_validate_test.go**: Unit tests for schema validation:
  - Invalid operation/object_table/entity_table rejection
  - Empty string and zero value rejection
  - Cross-field constraint validation (acl_table/acl_id pairing)
  - ACL role and entity role field validation

### CI/CD Enhancement
- **build.yml**: Added diagnostic step to log valid ACL object_table values from live CiviCRM instance for documentation sync

### Bug Fix
- **resource_acl_test.go**: Fixed existing test to use valid `object_table` value (changed from unsupported `civicrm_saved_search` to `civicrm_group`)

## Notable Implementation Details

- Validation is based on CiviCRM 6.6 source code analysis (CRM/ACL/BAO/ACL.php)
- Distinguishes between values silently accepted by CiviCRM API but never evaluated (e.g., civicrm_saved_search) vs. actively enforced values
- Smart groups are addressed via civicrm_group (not civicrm_saved_search)
- Cross-resource linking tests verify that role values, entity IDs, and object IDs correctly reference related resources
- All tests include both Terraform state checks and direct CiviCRM API verification

https://claude.ai/code/session_014XCbaBQFQrGQbaJRmZiSFU